### PR TITLE
Feature: Add table print to files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ The aim of Well Belo Log is to ease the workflow of dealing with large ammounts 
   - [Working with Dlis files](#working-with-dlis-files)
     - [Searching for Dlis Files](#searching-for-dlis-files)
     - [Reading Dlis Files](#reading-dlis-files)
+    - [Table View](#table-view)
     - [to dataframe](#to-dataframe)
     - [to csv](#to-csv)
     - [to excel](#to-excel)
@@ -28,6 +29,7 @@ The aim of Well Belo Log is to ease the workflow of dealing with large ammounts 
   - [Working with Las files](#working-with-las-files)
     - [Searching for Las Files](#searching-for-las-files)
     - [Reading Las Files](#reading-las-files)
+    - [LasFile Table](#lasfile-table)
     - [Frame data to dataframe](#frame-data-to-dataframe)
     - [Frame data to csv](#frame-data-to-csv)
     - [Frame data to excel](#frame-data-to-excel)
@@ -37,6 +39,7 @@ The aim of Well Belo Log is to ease the workflow of dealing with large ammounts 
   - [Working with Lis files](#working-with-lis-files)
     - [Searching for Lis Files](#searching-for-lis-files)
     - [Reading Lis Files](#reading-lis-files)
+    - [Table View](#table-view-1)
     - [Frame data to dataframe](#frame-data-to-dataframe-1)
     - [Frame data to csv](#frame-data-to-csv-1)
     - [Frame data to excel](#frame-data-to-excel-1)
@@ -132,6 +135,26 @@ from webelog.belodlis import DlisReader
 
 reader = DlisReader()
 dlis_file = reader.process_physical_file('path/to/your/file.dlis')
+```
+### Table View
+Prints a table with the file information.
+```python
+from webelog.belodlis import DlisReader
+
+reader = DlisReader()
+dlis_file = reader.process_physical_file('path/to/your/file.dlis')
+dlis_file.table_view()
+```
+Will print something like this:
+```bash
+                           1PIR1AL_conv_ccl_canhoneio.dlis
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
+┃ File Name                       ┃ Curves                                   ┃ Error ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
+│ 1PIR1AL_conv_ccl_canhoneio.dlis │ ['TDEP', 'MINMK', 'LSPD', 'LTEN', 'CCL'] │ False │
+│ 1PIR1AL_conv_ccl_canhoneio.dlis │ ['TDEP', 'MINMK', 'LSPD', 'LTEN', 'CCL'] │ False │
+│ 1PIR1AL_conv_ccl_canhoneio.dlis │ ['TDEP', 'MINMK', 'LSPD', 'LTEN', 'CCL'] │ False │
+└─────────────────────────────────┴──────────────────────────────────────────┴───────┘
 ```
 ### to dataframe 
 To convert the data to a pandas dataframe.
@@ -259,6 +282,26 @@ from webelog.belolas import LasReader
 reader = LasReader()
 las_file = reader.process_las_file('path/to/your/file.las')
 ```
+
+### LasFile Table
+Prints a table with the file information.
+```python
+from webelog.belolas import LasReader
+
+reader = LasReader()
+las_file = reader.process_las_file('path/to/your/file.las')
+las_file.table_view()
+```
+
+```bash
+                                                       1-MPE-3-AL_hals-dslt-tdd-hgns-gr_resistividade_repetida.las
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
+┃ File Name                                                   ┃ Curves                                                                                          ┃ Error ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
+│ 1-MPE-3-AL_hals-dslt-tdd-hgns-gr_resistividade_repetida.las │ ['DEPT', 'DT', 'GR', 'HCAL', 'HDRA', 'HLLD', 'HLLS', 'HRM', 'HSO', 'HTEM', 'ITT', 'NPHI',       │ False │
+│                                                             │ 'PEFZ', 'RHOZ']                                                                                 │       │
+└─────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────┴───────┘
+```
 ### Frame data to dataframe
 To convert the data to a pandas dataframe.
 
@@ -360,6 +403,25 @@ from webelog.belolas import LisReader
 
 reader = LisReader()
 lis_file = reader.process_physical_file('path/to/your/file.lis')
+```
+### Table View
+Prints a table with the file information.
+```python
+from webelog.belolas import LisReader
+
+reader = LisReader()
+lis_file = reader.process_lis_file('path/to/your/file.lis')
+lis_file.table_view()
+```
+Will print something like this:
+```bash
+                                                            1-MPE-3-AL.lis
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
+┃ File Name      ┃ Curves                                                                                                     ┃ Error ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
+│ 1-MPE-3-AL.lis │ []                                                                                                         │ False │
+│ 1-MPE-3-AL.lis │ ['SP', 'SN', 'TBHV', 'DIR', 'ABHV', 'DEPT', 'DT', 'GR', 'ITT', 'TT4', 'TT1', 'YCAL', 'XCAL', 'TT3', 'TT2'] │ False │
+└────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────┘
 ```
 
 ### Frame data to dataframe

--- a/examples/example.py
+++ b/examples/example.py
@@ -8,4 +8,4 @@ if __name__ == '__main__':
     reader = LisReader()
     file = reader.process_physical_file(PATH_TO_FILE)
     print(file.file_name)
-    print(file)
+    print(file.logical_files_table())

--- a/examples/example_dlis.py
+++ b/examples/example_dlis.py
@@ -1,0 +1,12 @@
+
+from wellbelog.belodlis.reader import DlisReader  # noqa
+
+
+if __name__ == '__main__':
+    PATH_TO_FILE = r'test\test_files\1PIR1AL_conv_ccl_canhoneio.dlis'
+
+    reader = DlisReader()
+    file = reader.process_physical_file(PATH_TO_FILE)
+    print(file.file_name)
+    print(file.logical_files_table())
+    table = file.logical_files_table()

--- a/examples/example_las.py
+++ b/examples/example_las.py
@@ -1,0 +1,11 @@
+
+from wellbelog.belolas.reader import LasReader  # noqa
+
+
+if __name__ == '__main__':
+    PATH_TO_FILE = r'test\test_files\1-MPE-3-AL_hals-dslt-tdd-hgns-gr_resistividade_repetida.las'
+
+    reader = LasReader()
+    file = reader.process_las_file(PATH_TO_FILE)
+    print(file.file_name)
+    print(file.table_view())

--- a/test/lis/test_lis_export.py
+++ b/test/lis/test_lis_export.py
@@ -17,7 +17,7 @@ def test_lis_to_csv():
     assert logical_file.file_name == '1-MPE-3-AL.lis'
     assert logical_file.error is False
 
-    curve_data = logical_file.curves_data[1]
+    curve_data = logical_file.frames[1]
     with tempfile.TemporaryDirectory() as tmpdirname:
         csv_path = f'{tmpdirname}/1-MPE-3-AL.csv'
         curve_data.to_csv(csv_path)

--- a/wellbelog/belolas/schemas/las.py
+++ b/wellbelog/belolas/schemas/las.py
@@ -1,7 +1,11 @@
+from functools import cached_property
 from typing import Any, Optional
+
 from pydantic import BaseModel, Field
+from rich.table import Table
 
 from wellbelog.db.base import TimeStampedModelSchema, DataframeSchema
+from wellbelog.utils.console import console
 
 
 class LasDataframe(DataframeSchema):
@@ -62,3 +66,19 @@ class LasFileModel(TimeStampedModelSchema):
             if spec.mnemonic == column:
                 return spec
         return None
+
+    @cached_property
+    def curves_names(self) -> list[str]:
+        return [spec.mnemonic for spec in self.specs]
+
+    def table_view(self) -> Table:
+        """
+        Create a table view of the file.
+        """
+        table = Table(title=self.file_name)
+        table.add_column("File Name", style="green")
+        table.add_column("Curves", style="cyan")
+        table.add_column("Error", style="red")
+        table.add_row(self.file_name, str(self.curves_names), str(self.error),)
+        console.print(table)
+        return table

--- a/wellbelog/belolis/reader.py
+++ b/wellbelog/belolis/reader.py
@@ -101,7 +101,7 @@ class LisReader:
                         logical_file_id=logical_file_id,
                         data=json.loads(curve.to_json(orient="records")),
                     )
-                    logical_file_model.curves_data.append(curve_model)
+                    logical_file_model.frames.append(curve_model)
                     for curve_name in curve.columns:
                         curves_set_names.add(curve_name)
                 logical_file_model.curves_names = list(curves_set_names)


### PR DESCRIPTION
# WellBeLog Pull Request

Added table views using rich to all files extensions.

### What I did:

- Added table print to dlis, lis, and las files schemas.
- update documentation

### How to test:

- There are instructions on the readme on how to do it.
-Basically is something like this:
### Table View
Prints a table with the file information.
```python
from webelog.belodlis import DlisReader

reader = DlisReader()
dlis_file = reader.process_physical_file('path/to/your/file.dlis')
dlis_file.table_view()
```
Will print something like this:
```bash
                           1PIR1AL_conv_ccl_canhoneio.dlis
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
┃ File Name                       ┃ Curves                                   ┃ Error ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
│ 1PIR1AL_conv_ccl_canhoneio.dlis │ ['TDEP', 'MINMK', 'LSPD', 'LTEN', 'CCL'] │ False │
│ 1PIR1AL_conv_ccl_canhoneio.dlis │ ['TDEP', 'MINMK', 'LSPD', 'LTEN', 'CCL'] │ False │
│ 1PIR1AL_conv_ccl_canhoneio.dlis │ ['TDEP', 'MINMK', 'LSPD', 'LTEN', 'CCL'] │ False │
└─────────────────────────────────┴──────────────────────────────────────────┴───────┘
```

